### PR TITLE
Revert "wt88047: dts: Goodbye Tux, I love you"

### DIFF
--- a/arch/arm/boot/dts/qcom/wt88047/msm8916-wt88047.dtsi
+++ b/arch/arm/boot/dts/qcom/wt88047/msm8916-wt88047.dtsi
@@ -30,7 +30,7 @@
                         label = "pstore_reserve_mem";
                 };
 
-                splash_region@83000000 {
+                splash_region@83000000 { /* Give this region to mdss_fb0 */
                         status = "disabled";
                 };
 
@@ -145,10 +145,12 @@
 	qcom,mdss-pref-prim-intf = "dsi";
 	qcom,vbif-settings = <0x4 0x1>, <0xd8 0x707>, <0x124 0x3>;
 
-	/* mdss_fb0: qcom,mdss_fb_primary {
+	mdss_fb0: qcom,mdss_fb_primary {
+		/* Ketut P. Kumajaya: For old bootloader, old splash image */
+		/* Both recovery and bootanimation framebuffer need this */
 		qcom,memblock-reserve = <0x83200000 0xfa0000>;
 		qcom,mdss-fb-splash-logo-enabled;
-	}; */
+	};
 };
 
 &pmx_mdss {


### PR DESCRIPTION
This reverts commit 50fa5a267a16961ddd9980ad8d600f5a17e3db60.

Different LCD and bootloader combination still need this
workaround to avoid LCD garbages on init or no bootanimation
issue